### PR TITLE
Uninitialized variable causes problems on FileZilla

### DIFF
--- a/vfs.c
+++ b/vfs.c
@@ -129,7 +129,13 @@ void vfs_closedir(vfs_dir_t* dir) {
 	free(dir);
 }
 
-struct tm dummy;
+struct tm dummy = {
+	.tm_year = 1970,
+	.tm_mon  = 1,
+	.tm_mday = 1,
+	.tm_hour = 0,
+	.tm_min  = 0
+};
 struct tm* gmtime(time_t* c_t) {
 	return &dummy;
 }


### PR DESCRIPTION
Uninitialized "dummy" variable causes wrong date text to be sent to clients and FileZilla can not cope with invalid dates (day > 31, month > 12). It assumes wrong date text as part of file names and makes it impossible to send-receive files since it uses wrongly parsed file names with RETR - STOR commands.