### PR TITLE
Fix unhandled TYPE command

### DIFF
--- a/ftpd.c
+++ b/ftpd.c
@@ -945,7 +945,7 @@ static void cmd_abrt(const char *arg, struct tcp_pcb *pcb, struct ftpd_msgstate 
 static void cmd_type(const char *arg, struct tcp_pcb *pcb, struct ftpd_msgstate *fsm)
 {
 	dbg_printf("Got TYPE -%s-\n", arg);
-	send_msg(pcb, fsm, msg502);
+	send_msg(pcb, fsm, msg200);
 }
 
 static void cmd_mode(const char *arg, struct tcp_pcb *pcb, struct ftpd_msgstate *fsm)

--- a/ftpd.c
+++ b/ftpd.c
@@ -945,6 +945,12 @@ static void cmd_abrt(const char *arg, struct tcp_pcb *pcb, struct ftpd_msgstate 
 static void cmd_type(const char *arg, struct tcp_pcb *pcb, struct ftpd_msgstate *fsm)
 {
 	dbg_printf("Got TYPE -%s-\n", arg);
+	
+	if(strcmp(arg, "I") != 0) {
+		send_msg(pcb, fsm, msg502);
+		return;
+	}
+	
 	send_msg(pcb, fsm, msg200);
 }
 


### PR DESCRIPTION
FileZilla and most other FTP clients are not able to cope with unhandled TYPE command. Return success instead of command not implemented.