### PR TITLE
Fix wrong initialization of tm.tm_mon

### DIFF
--- a/vfs.c
+++ b/vfs.c
@@ -131,7 +131,7 @@ void vfs_closedir(vfs_dir_t* dir) {
 
 struct tm dummy = {
 	.tm_year = 1970,
-	.tm_mon  = 1,
+	.tm_mon  = 0,
 	.tm_mday = 1,
 	.tm_hour = 0,
 	.tm_min  = 0

--- a/vfs.c
+++ b/vfs.c
@@ -130,7 +130,7 @@ void vfs_closedir(vfs_dir_t* dir) {
 }
 
 struct tm dummy = {
-	.tm_year = 1970,
+	.tm_year = 70,
 	.tm_mon  = 0,
 	.tm_mday = 1,
 	.tm_hour = 0,


### PR DESCRIPTION
According to https://linux.die.net/man/3/gmtime, the month-field of struct tm ranges from 0 to 11.